### PR TITLE
Removed Duplicates from Default.xml and Remove.xml

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -404,7 +404,6 @@
   <project path="external/mime-support" name="platform/external/mime-support" groups="pdk" />
   <project path="external/minigbm" name="platform/external/minigbm" groups="pdk" />
   <project path="external/minijail" name="platform/external/minijail" groups="pdk" />
-  <project path="external/mksh" name="platform/external/mksh" groups="pdk" />
   <project path="external/python/mobly" name="platform/external/python/mobly" groups="pdk" />
   <project path="external/mobile-data-download" name="platform/external/mobile-data-download" groups="pdk" />
   <project path="external/mobly-bundled-snippets" name="platform/external/mobly-bundled-snippets" groups="pdk" />

--- a/snippets/remove.xml
+++ b/snippets/remove.xml
@@ -72,7 +72,7 @@
   <remove-project name="device/linaro/hikey-kernel" />
   <remove-project name="device/linaro/poplar" />
   <remove-project name="device/linaro/poplar-kernel" />
-  <remove-project name="device/mediatek/wembley-sepolicy" />
+  
   <remove-project name="device/sample" />
   <remove-project name="device/ti/beagle-x15" />
   <remove-project name="device/ti/beagle-x15-kernel" />
@@ -84,7 +84,6 @@
   
   <!-- Hardware repos -->
   <remove-project name="platform/hardware/qcom/wlan" />
-  <remove-project name="platform/hardware/qcom/sdm845/display" />
   <remove-project name="platform/hardware/qcom/gps" />
   <remove-project name="platform/hardware/libhardware" />
   <remove-project name="platform/hardware/libhardware_legacy" />


### PR DESCRIPTION
  This was from Default.xml due to it being in arrow.xml 

<project path="external/mksh" name="platform/external/mksh" groups="pdk" />

These lines was removed as they did not exist in repositorys or was not found at all

<remove-project name="platform/hardware/qcom/sdm845/display" />
<remove-project name="device/mediatek/wembley-sepolicy" />