### PR TITLE
manifest: Point to right qcom sepolicy_vndr-legacy-um path

### DIFF
--- a/snippets/droidx.xml
+++ b/snippets/droidx.xml
@@ -67,7 +67,7 @@
   <project path="device/qcom/sepolicy_vndr/sm8450" name="device_qcom_sepolicy_vndr" remote="droidx" revision="14-sm8450" />
   <project path="device/qcom/sepolicy_vndr/sm8550" name="device_qcom_sepolicy_vndr" remote="droidx" revision="14-sm8550" />
   <project path="device/qcom/sepolicy-legacy-um" name="device_qcom_sepolicy-legacy-um" remote="droidx" />
-  <project path="device/qcom/sepolicy_vndr-legacy-um" name="device_qcom_sepolicy_vndr-legacy-um" remote="droidx" />
+  <project path="device/qcom/sepolicy_vndr/legacy-um" name="device_qcom_sepolicy_vndr-legacy-um" remote="droidx" />
   <project path="device/mediatek/sepolicy_vndr" name="device_mediatek_sepolicy_vndr" remote="droidx" />
   <project path="device/samsung_slsi/sepolicy" name="device_samsung_slsi_sepolicy" remote="droidx" />
 


### PR DESCRIPTION
According to the new structure.

Change-Id: I781a6ff4b56016d44a4bb13bbe869594b09d4327