### PR TITLE
manifest: fix non-existent project error (platform/packages/apps/nfc)

### DIFF
--- a/snippets/remove.xml
+++ b/snippets/remove.xml
@@ -101,7 +101,6 @@
 
   <!-- Packages repos -->
   <remove-project name="platform/packages/apps/Settings" />
-  <remove-project name="platform/packages/apps/Nfc" />
   <remove-project name="platform/packages/modules/Bluetooth" />
   <remove-project name="platform/packages/modules/Wifi" />
   <remove-project name="platform/packages/apps/ThemePicker" />


### PR DESCRIPTION
fatal: manifest 'default.xml' not available
fatal: remove-project element specifies non-existent project: <remove-project name="platform/packages/apps/Nfc"/>